### PR TITLE
Fixed name of thrown errors as the controller determines if it's an e…

### DIFF
--- a/Api-Gateway/Services/ServiceDraftOrderController.cs
+++ b/Api-Gateway/Services/ServiceDraftOrderController.cs
@@ -52,7 +52,7 @@ public class ServiceDraftOrderController
         catch (Exception ex)
         {
             // Return 503 Service Unavailable if an exception occurs
-            return (503, $"Exception: {ex.Message}");
+            return (503, $"Error: {ex.Message}");
         }
     }
 

--- a/Api-Gateway/Services/ServiceEmailApiController.cs
+++ b/Api-Gateway/Services/ServiceEmailApiController.cs
@@ -52,7 +52,7 @@ public class ServiceEmailApiController
         catch (Exception ex)
         {
             // Return 503 Service Unavailable if an exception occurs
-            return (503, $"Exception: {ex.Message}");
+            return (503, $"Error: {ex.Message}");
         }
     }
 }

--- a/Api-Gateway/Services/ServiceOrderController.cs
+++ b/Api-Gateway/Services/ServiceOrderController.cs
@@ -47,7 +47,7 @@ public class ServiceOrderController
         catch (Exception ex)
         {
             // Return error details in case of an exception
-            return $"Exception: {ex.Message}";
+            return $"Error: {ex.Message}";
         } 
     }
     
@@ -80,7 +80,7 @@ public class ServiceOrderController
         catch (Exception ex)
         {
             // Return error details in case of an exception
-            return $"Exception: {ex.Message}";
+            return $"Error: {ex.Message}";
         }
     }
     
@@ -108,7 +108,7 @@ public class ServiceOrderController
         {
             return new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable)
             {
-                Content = new StringContent($"Exception: {ex.Message}")
+                Content = new StringContent($"Error: {ex.Message}")
             };
         }
         catch (Exception ex)
@@ -116,7 +116,7 @@ public class ServiceOrderController
             // Return a response with an exception message if something goes wrong
             return new HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError)
             {
-                Content = new StringContent($"Exception: {ex.Message}")
+                Content = new StringContent($"Error: {ex.Message}")
             };
         }
     }

--- a/Api-Gateway/Services/ServiceProductController.cs
+++ b/Api-Gateway/Services/ServiceProductController.cs
@@ -52,7 +52,7 @@ public class ServiceProductController
         catch (Exception ex)
         {
             // Return error details in case of an exception
-            return $"Exception: {ex.Message}";
+            return $"Error: {ex.Message}";
         }
     }
 
@@ -89,7 +89,7 @@ public class ServiceProductController
         catch (Exception ex)
         {
             // Return error details in case of an exception
-            return $"Exception: {ex.Message}";
+            return $"Error: {ex.Message}";
         }
     }
 
@@ -121,7 +121,7 @@ public class ServiceProductController
         {
             return new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable)
             {
-                Content = new StringContent($"Exception: {ex.Message}")
+                Content = new StringContent($"Error: {ex.Message}")
             };
         }
         catch (Exception ex)
@@ -129,7 +129,7 @@ public class ServiceProductController
             // Return a response with an exception message if something goes wrong
             return new HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError)
             {
-                Content = new StringContent($"Exception: {ex.Message}")
+                Content = new StringContent($"Error: {ex.Message}")
             };
         }
     }
@@ -163,7 +163,7 @@ public class ServiceProductController
         {
             return new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable)
             {
-                Content = new StringContent($"Exception: {ex.Message}")
+                Content = new StringContent($"Error: {ex.Message}")
             };
         }
         catch (Exception ex)
@@ -171,7 +171,7 @@ public class ServiceProductController
             // Return a response with an exception message if something goes wrong
             return new HttpResponseMessage(System.Net.HttpStatusCode.InternalServerError)
             {
-                Content = new StringContent($"Exception: {ex.Message}")
+                Content = new StringContent($"Error: {ex.Message}")
             };
         }
     }
@@ -210,7 +210,7 @@ public class ServiceProductController
         catch (Exception ex)
         {
             // Return error details in case of an exception
-            return $"Exception: {ex.Message}";
+            return $"Error: {ex.Message}";
         }
     }
 }

--- a/TestingProject/Api-Gateway/Services/ServiceDraftOrderControllerTest.cs
+++ b/TestingProject/Api-Gateway/Services/ServiceDraftOrderControllerTest.cs
@@ -114,7 +114,7 @@ namespace TestingProject.Api_Gateway.Services
 
             // Assert: Validate the exception message
             Assert.AreEqual(503, result.StatusCode);
-            Assert.AreEqual("Exception: Test Exception", result.Content);
+            Assert.AreEqual("Error: Test Exception", result.Content);
         }
         
     }

--- a/TestingProject/Api-Gateway/Services/ServiceOrderControllerTest.cs
+++ b/TestingProject/Api-Gateway/Services/ServiceOrderControllerTest.cs
@@ -104,7 +104,7 @@ public class ServiceOrderControllerTest
         var result = await _serviceOrderController.GetAllOrdersAsync();
 
         // Assert: Validate the exception message
-        Assert.AreEqual("Exception: Test Exception", result);
+        Assert.AreEqual("Error: Test Exception", result);
     }
 
     [Test]
@@ -191,7 +191,7 @@ public class ServiceOrderControllerTest
         var result = await _serviceOrderController.GetOrderByIdAsync(1);
 
         // Assert: Validate the exception message
-        Assert.AreEqual("Exception: Test Exception", result);
+        Assert.AreEqual("Error: Test Exception", result);
     }
     
     [Test]
@@ -219,7 +219,7 @@ public class ServiceOrderControllerTest
 
         // Assert: Validate the exception message and status code
         Assert.AreEqual(System.Net.HttpStatusCode.ServiceUnavailable, result.StatusCode);
-        Assert.AreEqual("Exception: Network error", await result.Content.ReadAsStringAsync());
+        Assert.AreEqual("Error: Network error", await result.Content.ReadAsStringAsync());
     }
     
     [Test]
@@ -247,7 +247,7 @@ public class ServiceOrderControllerTest
 
         // Assert: Validate the exception message and status code
         Assert.AreEqual(System.Net.HttpStatusCode.InternalServerError, result.StatusCode);
-        Assert.AreEqual("Exception: Unexpected error", await result.Content.ReadAsStringAsync());
+        Assert.AreEqual("Error: Unexpected error", await result.Content.ReadAsStringAsync());
     }
     
     [Test]

--- a/TestingProject/Api-Gateway/Services/ServiceProductControllerTest.cs
+++ b/TestingProject/Api-Gateway/Services/ServiceProductControllerTest.cs
@@ -99,7 +99,7 @@ public class ServiceProductControllerTest
         var result = await _serviceProductController.GetAllProductsAsync();
 
         // Assert
-        Assert.That(result, Is.EqualTo("Exception: Unexpected error"));
+        Assert.That(result, Is.EqualTo("Error: Unexpected error"));
     }
     // ------- GET Get By ID
     [Test]
@@ -202,7 +202,7 @@ public class ServiceProductControllerTest
         var result = await _serviceProductController.GetProductByIdAsync(productId);
 
         // Assert
-        Assert.That(result, Is.EqualTo("Exception: Unexpected error"));
+        Assert.That(result, Is.EqualTo("Error: Unexpected error"));
     }
 
     
@@ -262,7 +262,7 @@ public class ServiceProductControllerTest
 
         // Assert
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.ServiceUnavailable));
-        Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo("Exception: Network error"));
+        Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo("Error: Network error"));
     }
     [Test]
     public async Task CreateProductAsync_ReturnsInternalServerError_WhenGeneralExceptionOccurs()
@@ -288,7 +288,7 @@ public class ServiceProductControllerTest
 
         // Assert
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
-        Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo("Exception: Unexpected error"));
+        Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo("Error: Unexpected error"));
     }
     [Test]
     public async Task CreateProductAsync_ReturnsBadRequest_WhenApiCallFails()
@@ -436,7 +436,7 @@ public class ServiceProductControllerTest
         var result = await _serviceProductController.DeleteProductAsync(productId);
 
         // Assert
-        Assert.That(result, Is.EqualTo("Exception: Unexpected error"));
+        Assert.That(result, Is.EqualTo("Error: Unexpected error"));
     }
 
 
@@ -501,7 +501,7 @@ public class ServiceProductControllerTest
 
         // Assert: Verify the response status and message
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.ServiceUnavailable));
-        Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo("Exception: Network error"));
+        Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo("Error: Network error"));
     }
     
     [Test]
@@ -530,7 +530,7 @@ public class ServiceProductControllerTest
 
         // Assert: Verify the response status and message
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
-        Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo("Exception: Unexpected error"));
+        Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo("Error: Unexpected error"));
     }
 
     [Test]


### PR DESCRIPTION
## Description

<!--Please include a summary of the changes and which issue is fixed. Also, list any dependencies that are required for this change.-->

Fixed services returning 200 if the service is closed for shopify and email service
The errors are being checked by the controller by seeing if it starts with "Error", however they started with "Exception", it was fixed
---

## Linked JIRA Ticket
<!--Please put the ticket number here, who it was assigned to and etch-->
https://champlainsaintlambert.atlassian.net/browse/HL-52
---
## Related Issue
<!--What Pr should we take in consideration while reviewing your PR-->
```text
The status code should not be 200 when the shopify (And email) service on our side is not running. The message is good, but not the status code.
```
---

<!-- To Check a box, do : [x]-->
## Type of Change
* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation

---
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my code on the relevant platforms
---
## UI Changes
No changes to UI

---
## Notes to Reviewer
Please make your error messages start with "Error" in the Api gateway
